### PR TITLE
fix: anchor LIB_DIR regex to start-of-line in gga formula

### DIFF
--- a/Formula/gga.rb
+++ b/Formula/gga.rb
@@ -21,8 +21,11 @@ class Gga < Formula
       "VERSION=\"#{version}\""
 
     # Update LIB_DIR path in the installed script
+    # NOTE: ^ anchor is critical — LIB_DIR= appears in the
+    # if ! LIB_DIR=$(resolve_lib_dir ...) conditional too,
+    # and matching both would break bash syntax.
     inreplace bin/"gga",
-      /LIB_DIR=.*/,
+      /^LIB_DIR=.*/,
       "LIB_DIR=\"#{libexec}/lib\""
   end
 


### PR DESCRIPTION
Closes Gentleman-Programming/gentleman-guardian-angel#105

## Summary

The `inreplace` pattern `/LIB_DIR=.*/` in the gga formula is too broad — it matches **both** the standalone `LIB_DIR=` assignment **and** the `if ! LIB_DIR=$(resolve_lib_dir ...); then` conditional, replacing both with a hardcoded path. The second replacement strips the command substitution and `; then`, producing a bash syntax error on every `gga` invocation.

## Fix

Anchor the regex with `^` so it only matches lines that start with `LIB_DIR=`, leaving the `if` conditional intact.

## Impact

Every user installing gga 2.10.0 via Homebrew gets a broken `gga` binary with:

```
/opt/homebrew/bin/gga: line 46: syntax error near unexpected token `fi'
```

## Changes

| File | Change |
|------|--------|
| `Formula/gga.rb` | Changed `/LIB_DIR=.*/` -> `/^LIB_DIR=.*/` with explanatory comment |

## Test Plan

- [x] Fixed formula in local install — `gga` works correctly after fix
- [x] Regex change verified against source `bin/gga` — only the intended line is matched
